### PR TITLE
Update workflows to use artifact actions v4 and update actions/cache …

### DIFF
--- a/.github/workflows/deprecated/jekyll-gh-pages.yml
+++ b/.github/workflows/deprecated/jekyll-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/.github/workflows/deprecated/password-policy-min-time.yml
+++ b/.github/workflows/deprecated/password-policy-min-time.yml
@@ -40,14 +40,14 @@ jobs:
           mkdir staging && cp PasswordMinTimePolicy/target/*.jar staging
 
       - name: Set up a cache for Maven
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
       - name: Persist workflow data as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: github-actions-artifact
           path: staging

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,11 +14,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Maven Central Repository
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
+        distribution: temurin
+        check-latest: true
+        cache: maven
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD


### PR DESCRIPTION
…from v2 to v4

Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)